### PR TITLE
Docs on how to point to a specific logspout image version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ dokku plugins-install
 dokku plugin:install https://github.com/michaelshobbs/dokku-logspout.git
 ```
 
+### Customization
+
+Configuration settings are stored in `/home/dokku/.logspout/OPTS`. If you would like
+to use a specific version of the logspout container, you can edit `OPTS` and modify
+the `DOKKU_LOGSPOUT_IMAGE_VERSION` to point to a specific image version.
+
 Commands
 --------
 ```


### PR DESCRIPTION
The recent 3.1 release was not pulled when I ran `dokku logspout:update`. I needed
to modify the `DOKKU_LOGSPOUT_IMAGE_VERSION` to pull the latest version.
