### PR TITLE
use is_container_status instead of deprecated is_container_running

### DIFF
--- a/commands
+++ b/commands
@@ -48,7 +48,7 @@ logspout_info_cmd() {
     CID=$(< "$DOKKU_LOGSPOUT_ROOT/CONTAINER")
     dokku_log_info2_quiet "logspout status"
 
-    if (is_container_running "$CID"); then
+    if (is_container_status "$CID" "Running"); then
       dokku_log_verbose "running"
     else
       dokku_log_verbose "not running"
@@ -125,7 +125,7 @@ logspout_start_cmd() {
     do_run
   else
     CID=$(< "$DOKKU_LOGSPOUT_ROOT/CONTAINER")
-    if (! is_container_running "$CID"); then
+    if (! is_container_status "$CID" "Running"); then
       docker rm -f logspout &>/dev/null || true
       do_run
     fi

--- a/plugin.toml
+++ b/plugin.toml
@@ -1,4 +1,4 @@
 [plugin]
 description = "sends dokku app stdout to a logging service"
-version = "0.3.0"
+version = "0.4.0"
 [plugin.config]


### PR DESCRIPTION
`is_container_status` was dropped in dokku 0.12.0

related to:
 - dokku/dokku#3109
 - gliderlabs/logspout#389
 - dokku/dokku#3155
